### PR TITLE
Unify tab UI across Library, Stream, and Now Playing

### DIFF
--- a/app/src/main/java/com/melodrive/ui/screens/NowPlayingScreen.kt
+++ b/app/src/main/java/com/melodrive/ui/screens/NowPlayingScreen.kt
@@ -102,7 +102,7 @@ fun NowPlayingScreen(
             }
             BufferList(
                 tracks = buffer,
-                currentId = buffer.firstOrNull { it.title == state.title && it.artist == state.artist }?.id.orEmpty(),
+                currentId = state.currentTrackId,
                 onPlayTrack = vm::playFromMainBuffer,
                 onRemoveTrack = { vm.removeFromMainBuffer(it.id) },
                 modifier = Modifier.weight(1f),

--- a/app/src/main/java/com/melodrive/ui/screens/NowPlayingViewModel.kt
+++ b/app/src/main/java/com/melodrive/ui/screens/NowPlayingViewModel.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 data class NowPlayingState(
+    val currentTrackId: String = "",
     val title: String = "",
     val artist: String = "",
     val artworkUri: Uri? = null,
@@ -66,6 +67,7 @@ class NowPlayingViewModel(app: Application) : AndroidViewModel(app) {
         override fun onMetadataChanged(metadata: MediaMetadataCompat?) {
             metadata ?: return
             _state.value = _state.value.copy(
+                currentTrackId = metadata.getString(MediaMetadataCompat.METADATA_KEY_MEDIA_ID) ?: "",
                 title = metadata.getString(MediaMetadataCompat.METADATA_KEY_TITLE) ?: "",
                 artist = metadata.getString(MediaMetadataCompat.METADATA_KEY_ARTIST) ?: "",
                 artworkUri = metadata.description.iconUri,
@@ -119,8 +121,8 @@ class NowPlayingViewModel(app: Application) : AndroidViewModel(app) {
         val removeIndex = current.indexOfFirst { it.id == trackId }
         if (removeIndex < 0) return
 
-        val isCurrentTrack = state.value.connected && state.value.title.isNotEmpty() &&
-                current.getOrNull(removeIndex)?.title == state.value.title
+        val isCurrentTrack = state.value.connected && state.value.currentTrackId.isNotEmpty() &&
+                current.getOrNull(removeIndex)?.id == state.value.currentTrackId
 
         val updated = MusicRepository.removeFromMainBuffer(trackId)
 

--- a/app/src/main/java/com/melodrive/ui/screens/StreamScreen.kt
+++ b/app/src/main/java/com/melodrive/ui/screens/StreamScreen.kt
@@ -80,7 +80,7 @@ fun StreamScreen(
                 onValueChange = vm::onQueryChange,
                 singleLine = true,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                keyboardActions = KeyboardActions(onSearch = { vm.search() }),
+                keyboardActions = KeyboardActions(onSearch = { if (!state.loading) vm.search() }),
                 textStyle = MaterialTheme.typography.bodyMedium.copy(
                     color = MaterialTheme.colorScheme.onSurface,
                 ),


### PR DESCRIPTION
## Summary

- **Stream**: added "Stream" title on the same row as the search field (with search icon as trailing icon); aligned padding to `20dp` horizontal to match Library
- **Now Playing buffer**: removed `contentPadding(top=16dp)` so the "Playing Buffer" title sits at the same height as other tabs; removed `Arrangement.spacedBy(8dp)` that created gaps between track rows; non-current track rows no longer have an explicit background color (current track keeps the subtle `surfaceVariant` highlight)
- All three tabs now share the same header height, horizontal padding (20dp), and track row styling — using Library as the reference

## Test plan

- [x] Library tab: header still looks correct, track/album rows unchanged
- [x] Stream tab: "Stream" title appears on the left, search field fills remaining space, search icon inside field works
- [x] Now Playing tab: "Playing Buffer" title is at the same height as Library's "Library" title; track rows have no gaps; current track is subtly highlighted; mini-player and full-player overlays unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Now Playing layout refreshed: persistent bottom mini-player, consolidated "Playing Buffer" header with conditional "Clear" visibility, tightened buffer list spacing, updated track-row background and increased mini-player padding for cleaner visuals.
  * Stream header spacing refined, "Stream" title added, and "Last played" padding standardized.

* **Refactor**
  * Stream search integrated into a single outlined field with explicit interaction handling and consistent decoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->