### PR TITLE
Fix playback issues: clear buffer, stream buffering state, and queue seeking

### DIFF
--- a/app/src/main/java/com/melodrive/service/MusicService.kt
+++ b/app/src/main/java/com/melodrive/service/MusicService.kt
@@ -23,6 +23,7 @@ import com.melodrive.model.TrackSource
 import com.melodrive.youtube.YtDlpWrapper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -42,6 +43,7 @@ class MusicService : MediaBrowserServiceCompat() {
 
     private val serviceJob = SupervisorJob()
     private val serviceScope = CoroutineScope(Dispatchers.Main + serviceJob)
+    private var playQueueJob: Job? = null
 
     private var queue: List<Track> = emptyList()
 
@@ -148,6 +150,7 @@ class MusicService : MediaBrowserServiceCompat() {
         override fun onPlay() = player.play()
         override fun onPause() = player.pause()
         override fun onStop() {
+            playQueueJob?.cancel()
             player.stop()
             player.clearMediaItems()
             queue = emptyList()
@@ -198,7 +201,8 @@ class MusicService : MediaBrowserServiceCompat() {
     }
 
     fun playQueue(tracks: List<Track>, startIndex: Int) {
-        serviceScope.launch {
+        playQueueJob?.cancel()
+        playQueueJob = serviceScope.launch {
             val startTrack = tracks.getOrNull(startIndex) ?: return@launch
 
             player.stop()
@@ -215,7 +219,14 @@ class MusicService : MediaBrowserServiceCompat() {
                 startTrack.uri
             }
 
-            if (startUri == null) return@launch // Skip if start track fails
+            if (startUri == null) {
+                mediaSession.setPlaybackState(
+                    PlaybackStateCompat.Builder()
+                        .setState(PlaybackStateCompat.STATE_STOPPED, 0, 0f)
+                        .build()
+                )
+                return@launch
+            }
 
             queue = listOf(startTrack)
             player.setMediaItem(MediaItem.fromUri(startUri))

--- a/app/src/main/java/com/melodrive/service/MusicService.kt
+++ b/app/src/main/java/com/melodrive/service/MusicService.kt
@@ -149,8 +149,16 @@ class MusicService : MediaBrowserServiceCompat() {
         override fun onPause() = player.pause()
         override fun onStop() {
             player.stop()
+            player.clearMediaItems()
+            queue = emptyList()
             stopForeground(STOP_FOREGROUND_REMOVE)
             mediaSession.isActive = false
+            mediaSession.setMetadata(null)
+            mediaSession.setPlaybackState(
+                PlaybackStateCompat.Builder()
+                    .setState(PlaybackStateCompat.STATE_NONE, 0, 0f)
+                    .build()
+            )
         }
 
         override fun onSkipToNext() = player.seekToNextMediaItem()
@@ -166,6 +174,12 @@ class MusicService : MediaBrowserServiceCompat() {
 
         override fun onPlayFromMediaId(mediaId: String?, extras: Bundle?) {
             val trackId = mediaId ?: return
+            val queueIndex = queue.indexOfFirst { it.id == trackId }
+            if (queueIndex >= 0) {
+                player.seekToDefaultPosition(queueIndex)
+                player.play()
+                return
+            }
             val tracks = MusicRepository.mainBuffer.value
             if (tracks.isEmpty()) return
             val index = tracks.indexOfFirst { it.id == trackId }
@@ -186,6 +200,15 @@ class MusicService : MediaBrowserServiceCompat() {
     fun playQueue(tracks: List<Track>, startIndex: Int) {
         serviceScope.launch {
             val startTrack = tracks.getOrNull(startIndex) ?: return@launch
+
+            player.stop()
+            updateMetadata(startTrack)
+            mediaSession.setPlaybackState(
+                PlaybackStateCompat.Builder()
+                    .setState(PlaybackStateCompat.STATE_BUFFERING, 0, 1f)
+                    .build()
+            )
+
             val startUri = if (startTrack.source == TrackSource.YOUTUBE) {
                 withContext(Dispatchers.IO) { YtDlpWrapper.resolveStreamUrl(startTrack.id) }
             } else {

--- a/app/src/main/java/com/melodrive/ui/screens/NowPlayingScreen.kt
+++ b/app/src/main/java/com/melodrive/ui/screens/NowPlayingScreen.kt
@@ -111,6 +111,7 @@ fun NowPlayingScreen(
                 title = state.title.ifEmpty { "Nothing Playing" },
                 artist = state.artist,
                 isPlaying = state.isPlaying,
+                isBuffering = state.isBuffering,
                 onSkipPrevious = vm::skipPrevious,
                 onTogglePlayPause = vm::togglePlayPause,
                 onSkipNext = vm::skipNext,
@@ -135,6 +136,7 @@ fun NowPlayingScreen(
                 artist = state.artist,
                 artworkUri = state.artworkUri,
                 isPlaying = state.isPlaying,
+                isBuffering = state.isBuffering,
                 positionMs = state.positionMs,
                 durationMs = state.durationMs,
                 repeatMode = state.repeatMode,
@@ -258,6 +260,7 @@ private fun MiniPlayer(
     title: String,
     artist: String,
     isPlaying: Boolean,
+    isBuffering: Boolean,
     onSkipPrevious: () -> Unit,
     onTogglePlayPause: () -> Unit,
     onSkipNext: () -> Unit,
@@ -296,11 +299,19 @@ private fun MiniPlayer(
             IconButton(onClick = onSkipPrevious) {
                 Icon(Icons.Default.SkipPrevious, contentDescription = "Previous")
             }
-            IconButton(onClick = onTogglePlayPause) {
-                Icon(
-                    imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                    contentDescription = "Play Pause",
+            if (isBuffering) {
+                androidx.compose.material3.CircularProgressIndicator(
+                    modifier = Modifier.padding(12.dp).size(24.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.onSurface
                 )
+            } else {
+                IconButton(onClick = onTogglePlayPause) {
+                    Icon(
+                        imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                        contentDescription = "Play Pause",
+                    )
+                }
             }
             IconButton(onClick = onSkipNext) {
                 Icon(Icons.Default.SkipNext, contentDescription = "Next")
@@ -315,6 +326,7 @@ private fun FullPlayer(
     artist: String,
     artworkUri: Uri?,
     isPlaying: Boolean,
+    isBuffering: Boolean,
     positionMs: Long,
     durationMs: Long,
     repeatMode: Int,
@@ -400,12 +412,20 @@ private fun FullPlayer(
             IconButton(onClick = onSkipPrevious, modifier = Modifier.size(56.dp)) {
                 Icon(Icons.Default.SkipPrevious, contentDescription = "Previous", modifier = Modifier.size(34.dp))
             }
-            IconButton(onClick = onTogglePlayPause, modifier = Modifier.size(68.dp)) {
-                Icon(
-                    imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                    contentDescription = "Play Pause",
-                    modifier = Modifier.size(40.dp),
+            if (isBuffering) {
+                androidx.compose.material3.CircularProgressIndicator(
+                    modifier = Modifier.padding(14.dp).size(40.dp),
+                    strokeWidth = 3.dp,
+                    color = MaterialTheme.colorScheme.onSurface
                 )
+            } else {
+                IconButton(onClick = onTogglePlayPause, modifier = Modifier.size(68.dp)) {
+                    Icon(
+                        imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                        contentDescription = "Play Pause",
+                        modifier = Modifier.size(40.dp),
+                    )
+                }
             }
             IconButton(onClick = onSkipNext, modifier = Modifier.size(56.dp)) {
                 Icon(Icons.Default.SkipNext, contentDescription = "Next", modifier = Modifier.size(34.dp))

--- a/app/src/main/java/com/melodrive/ui/screens/NowPlayingViewModel.kt
+++ b/app/src/main/java/com/melodrive/ui/screens/NowPlayingViewModel.kt
@@ -26,6 +26,7 @@ data class NowPlayingState(
     val artist: String = "",
     val artworkUri: Uri? = null,
     val isPlaying: Boolean = false,
+    val isBuffering: Boolean = false,
     val positionMs: Long = 0L,
     val durationMs: Long = 0L,
     val connected: Boolean = false,
@@ -77,8 +78,10 @@ class NowPlayingViewModel(app: Application) : AndroidViewModel(app) {
 
         override fun onPlaybackStateChanged(playbackState: PlaybackStateCompat?) {
             val isPlaying = playbackState?.state == PlaybackStateCompat.STATE_PLAYING
+            val isBuffering = playbackState?.state == PlaybackStateCompat.STATE_BUFFERING
             _state.value = _state.value.copy(
                 isPlaying = isPlaying,
+                isBuffering = isBuffering,
                 positionMs = currentPosition(playbackState),
             )
             if (isPlaying) startTicker() else stopTicker()
@@ -114,7 +117,17 @@ class NowPlayingViewModel(app: Application) : AndroidViewModel(app) {
 
     fun clearMainBuffer() {
         MusicRepository.clearMainBuffer()
-        if (state.value.isPlaying) controller?.transportControls?.pause()
+        controller?.transportControls?.stop()
+        _state.value = _state.value.copy(
+            currentTrackId = "",
+            title = "",
+            artist = "",
+            artworkUri = null,
+            durationMs = 0L,
+            positionMs = 0L,
+            isPlaying = false,
+            isBuffering = false
+        )
     }
 
     fun removeFromMainBuffer(trackId: String) {
@@ -139,7 +152,7 @@ class NowPlayingViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     fun playFromMainBuffer(track: Track) {
-        MusicRepository.addToMainBufferAndMoveToFront(track)
+        controller?.transportControls?.stop()
         controller?.transportControls?.playFromMediaId(track.id, null)
     }
 
@@ -147,7 +160,7 @@ class NowPlayingViewModel(app: Application) : AndroidViewModel(app) {
         val buffer = mainBuffer.value
         if (index !in buffer.indices) return
         val track = buffer[index]
-        MusicRepository.addToMainBufferAndMoveToFront(track)
+        controller?.transportControls?.stop()
         controller?.transportControls?.playFromMediaId(track.id, null)
     }
 

--- a/app/src/main/java/com/melodrive/ui/screens/NowPlayingViewModel.kt
+++ b/app/src/main/java/com/melodrive/ui/screens/NowPlayingViewModel.kt
@@ -152,7 +152,6 @@ class NowPlayingViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     fun playFromMainBuffer(track: Track) {
-        controller?.transportControls?.stop()
         controller?.transportControls?.playFromMediaId(track.id, null)
     }
 
@@ -160,7 +159,6 @@ class NowPlayingViewModel(app: Application) : AndroidViewModel(app) {
         val buffer = mainBuffer.value
         if (index !in buffer.indices) return
         val track = buffer[index]
-        controller?.transportControls?.stop()
         controller?.transportControls?.playFromMediaId(track.id, null)
     }
 


### PR DESCRIPTION
Fix clear buffer not clearing playing track, add loading state to stream loading, and fix track click shifting items in queue instead of jumping to them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visual buffering indicator (loading spinner) during music playback instead of standard play button.

* **Bug Fixes**
  * Improved queue navigation and playback state management for more reliable playback control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->