### PR TITLE
CI: Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+    push:
+        branches:
+            - master
+
+jobs:
+    build-and-release:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Set up JDK 17
+              uses: actions/setup-java@v4
+              with:
+                  java-version: "17"
+                  distribution: "temurin"
+                  cache: gradle
+
+            - name: Grant execute permission for gradlew
+              run: chmod +x gradlew
+
+            - name: Build Debug APK
+              # We build a debug APK so it can be installed on Android devices without
+              # requiring a custom keystore or signing secrets in the repository.
+              run: ./gradlew assembleDebug
+
+            - name: Rename APK
+              run: mv app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/debug/melodrive-v0.1.${{ github.run_number }}.apk
+
+            - name: Upload APK as Artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: melodrive-apk
+                  path: app/build/outputs/apk/debug/melodrive-v0.1.${{ github.run_number }}.apk
+
+            - name: Create GitHub Release
+              uses: softprops/action-gh-release@v2
+              with:
+                  tag_name: v0.1.${{ github.run_number }}
+                  name: Melodrive v0.1.${{ github.run_number }}
+                  files: app/build/outputs/apk/debug/melodrive-v0.1.${{ github.run_number }}.apk
+                  generate_release_notes: true


### PR DESCRIPTION
Adds a GitHub Actions workflow to automatically build the APK and publish a GitHub Release when changes are pushed to `master`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated release workflow that builds and publishes versioned Android APKs to GitHub on every master branch update, making releases readily available as downloadable artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->